### PR TITLE
Lazily init document.scrollingElement + fixes.

### DIFF
--- a/scrollingelement.js
+++ b/scrollingelement.js
@@ -1,25 +1,33 @@
 /*! https://mths.be/scrollingelement v1.2.0 by @diegoperini & @mathias | MIT license */
 if (!('scrollingElement' in document)) (function() {
 
-	var html = document.documentElement;
-	var isCompliant = false;
-	var isStandardsMode = /^CSS1/.test(document.compatMode);
+	var isCompliantCached;
 
-	if (isStandardsMode) {
-		var iframe = document.createElement('iframe');
-		iframe.style.height = '1px';
-		(document.body || html).appendChild(iframe);
-		var doc = iframe.contentWindow.document;
-		doc.write('<!DOCTYPE html><div style="height:9999em">x</div>');
-		doc.close();
-		isCompliant = doc.documentElement.scrollHeight > doc.body.scrollHeight;
-		iframe.parentNode.removeChild(iframe);
-	}
+	var isCompliant = function() {
+		var isStandardsMode = /^CSS1/.test(document.compatMode);
+		if (!isStandardsMode) {
+			// Always non-compliant in quirks mode.
+			return false;
+		}
+		if (isCompliantCached === void 0) {
+			// When called for the first time, check whether the browser is
+			// standard-compliant, and cache the result.
+			var iframe = document.createElement('iframe');
+			iframe.style.height = '1px';
+			(document.body || document.documentElement).appendChild(iframe);
+			var doc = iframe.contentWindow.document;
+			doc.write('<!DOCTYPE html><div style="height:9999em">x</div>');
+			doc.close();
+			isCompliantCached = doc.documentElement.scrollHeight > doc.body.scrollHeight;
+			iframe.parentNode.removeChild(iframe);
+		}
+		return isCompliantCached;
+	};
 
 	var scrollingElement = function() {
 		var body = document.body;
-		if (isCompliant) { // Note: this is `isStandardsMode && isCompliant`.
-			return html;
+		if (isCompliant()) {
+			return document.documentElement;
 		}
 		// Note: `document.body` could be a `frameset` element, or `null`.
 		// `tagName` is uppercase in HTML, but lowercase in XML.

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2,14 +2,37 @@
 	'use strict';
 
 	var frameDoc = document.getElementsByTagName('iframe')[0].contentDocument;
-	var isStandardsMode = /^CSS1/.test(document.compatMode);
-	var isQuirksMode = !isStandardsMode;
+	function isStandardsMode() {
+		return /^CSS1/.test(document.compatMode);
+	}
+
+	function documentWritePreserveQunit(willBeStandardsMode) {
+		var htmlPrefix = willBeStandardsMode ? '<!DOCTYPE html>' : '<!-- no doctype = quirks mode -->';
+		var origDocElem = document.documentElement;
+		var headHTML = document.head.innerHTML;
+		var qunitDiv = document.getElementById('qunit');
+		document.close(); // Just in case
+		document.open();
+		document.write(htmlPrefix + '<html><head>' + headHTML + '</head><body></body></html>');
+		document.close();
+		document.body.appendChild(qunitDiv);
+
+		// Sanity check.
+		ok(document.documentElement !== origDocElem, '<html> should have been replaced.');
+		if (willBeStandardsMode) {
+			ok(isStandardsMode(), 'document should have been switched to standards mode.');
+		} else {
+			ok(!isStandardsMode(), 'document should have been switched to quirks mode.');
+		}
+	}
+
 	// Note: we cannot *really* test standards mode, as WebKit & Blink violate the
 	// spec and return `BODY` anyway, and our polyfill is supposed to mimic that.
-	if (isStandardsMode) {
+	if (isStandardsMode()) {
 		test('In standards mode in a non-frameset document, the scrolling element is supposed to be `HTML`', function() {
 			ok(
-				/HTML|BODY/.test(document.scrollingElement.tagName),
+				document.scrollingElement === document.body ||
+				document.scrollingElement === document.documentElement,
 				'In standards mode in a non-frameset document, the scrolling element is supposed to be `HTML`, but we’ll accept `BODY` too because that’s what WebKit/Blink use. Actual result: ' + document.scrollingElement.tagName
 			);
 		});
@@ -20,8 +43,16 @@
 				'[flaky test; retry as needed] In standards mode in a frameset document, the scrolling element is supposed to be `HTML`, but we’ll accept `null` too because that’s what it should be in WebKit/Blink. Actual result: ' + frameDoc.scrollingElement
 			);
 		});
-	}
-	if (isQuirksMode) {
+		test('after switching to quirks mode in a non-frameset document, the scrolling element is `BODY`', function() {
+			documentWritePreserveQunit(false);
+
+			strictEqual(
+				document.scrollingElement,
+				document.body,
+				'After switching to quirks mode in a non-frameset document, the scrolling element is `BODY`'
+			);
+		});
+	} else { // Not standards mode; Quirks mode.
 		test('In quirks mode in a non-frameset document, the scrolling element is `BODY`', function() {
 			strictEqual(
 				document.scrollingElement,
@@ -34,6 +65,15 @@
 				frameDoc.scrollingElement,
 				null,
 				'[flaky test; retry as needed] In quirks mode in a frameset document, the scrolling element is `null`'
+			);
+		});
+		test('after switching to standards mode in a non-frameset document, the scrolling element is supposed to be `HTML`', function() {
+			documentWritePreserveQunit(true);
+
+			ok(
+				document.scrollingElement === document.body ||
+				document.scrollingElement === document.documentElement,
+				'After switching to standards mode in a non-frameset document, the scrolling element is supposed to be `HTML`, but we’ll accept `BODY` too because that’s what WebKit/Blink use. Actual result: ' + document.scrollingElement.tagName
 			);
 		});
 	}


### PR DESCRIPTION
- Lazily init `document.scrollingElement`, i.e. only perform the feature detection using iframes if `document.scrollingElement` is actually used.
- Do not save the `document.documentElement` object in a local variable, because this object changes after calling `document.write`.
- Check for the document mode whenever `document.scrollingElement` is called, because standards mode/quirks mode can be toggled at runtime via document.write.

Added new tests to catch the last issue. In Firefox 37.0, the new test fails with the old code, but passes with the new logic (standards-mode.html). The new test succeeds in Chrome 41.0.2271.77 regardless of the code changes, but that is caused by the fact that the "isCompliant" branch is never taken.
