### PR TITLE
Fixed getComputedStyle in older browsers

### DIFF
--- a/scrollingelement.js
+++ b/scrollingelement.js
@@ -1,5 +1,14 @@
 /*! https://mths.be/scrollingelement v1.5.0 by @diegoperini & @mathias | MIT license */
 if (!('scrollingElement' in document)) (function() {
+	function computeStyle(element) {
+		if ("getComputedStyle" in window) {
+			// Support Firefox < 4 (throws on a single parameter).
+			return getComputedStyle(element, null);
+		}
+		
+		// Support Internet Explorer < 9.
+		return element.currentStyle;
+	}
 	function isBodyElement(element) {
 		// The `instanceof` check gives the correct result for e.g. `body` in a
 		// non-HTML namespace.
@@ -56,8 +65,8 @@ if (!('scrollingElement' in document)) (function() {
 	function isScrollable(body) {
 		// A `body` element is scrollable if `body` and `html` both have
 		// non-`visible` overflow and are both being rendered.
-		var bodyStyle = getComputedStyle(body);
-		var htmlStyle = getComputedStyle(document.documentElement);
+		var bodyStyle = computeStyle(body);
+		var htmlStyle = computeStyle(document.documentElement);
 		return bodyStyle.overflow != 'visible' && htmlStyle.overflow != 'visible' &&
 			isRendered(bodyStyle) && isRendered(htmlStyle);
 	}


### PR DESCRIPTION
Firefox < 4 throws on `getComputedStyle(element)`; it needs `getComputedStyle(element, null)`. The second argument is a name of a pseudo element, which can be `null` but must be supplied.
Internet Explorer < 9 did not implement `getComputedStyle`. Instead, `element.currentStyle` exists.

I have not tested it, I just know those were not supported.
I do not think Firefox < 4 even needs support here (almost nonexistent market share), but you already added code to support it.
