### PR TITLE
Make safe to include and run in a node environment

### DIFF
--- a/scrollingelement.js
+++ b/scrollingelement.js
@@ -1,5 +1,5 @@
 /*! https://mths.be/scrollingelement v1.5.1 by @diegoperini & @mathias | MIT license */
-if (!('scrollingElement' in document)) (function() {
+if (typeof document !== 'undefined' && !('scrollingElement' in document)) (function() {
 
 	function computeStyle(element) {
 		if (window.getComputedStyle) {


### PR DESCRIPTION
Check to see if `document` exists before trying to install the polyfill. This makes it safe to run in a node environment and blindly include in a build for "isomorphic" projects.
