### PR TITLE
Do not return null in standards mode.

### DIFF
--- a/scrollingelement.js
+++ b/scrollingelement.js
@@ -36,12 +36,15 @@ if (!('scrollingElement' in document)) (function() {
 		return null;
 	}
 
+	function isStandardsMode() {
+		return /^CSS1/.test(document.compatMode);
+	}
+
 	// Note: standards mode / quirks mode can be toggled at runtime via
 	// `document.write`.
 	var isCompliantCached;
 	var isCompliant = function() {
-		var isStandardsMode = /^CSS1/.test(document.compatMode);
-		if (!isStandardsMode) {
+		if (!isStandardsMode()) {
 			// In quirks mode, the result is equivalent to the non-compliant
 			// standards mode behavior.
 			return false;
@@ -85,7 +88,7 @@ if (!('scrollingElement' in document)) (function() {
 		var isFrameset = body && !/body/i.test(body.tagName);
 		body = isFrameset ? getNextBodyElement(body) : body;
 		// If `body` is itself scrollable, it is not the `scrollingElement`.
-		return body && isScrollable(body) ? null : body;
+		return body && !isStandardsMode() && isScrollable(body) ? null : body;
 	};
 
 	if (Object.defineProperty) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -50,6 +50,15 @@
 				'[flaky test; retry as needed] In standards mode in a frameset document, the scrolling element is supposed to be `HTML`, but we’ll accept `null` too because that’s what it should be in WebKit/Blink. Actual result: ' + frameDoc.scrollingElement
 			);
 		});
+		test('In standards mode, if the `BODY` is scrollable, the scrolling element is supposed to be `HTML`', function() {
+			document.documentElement.setAttribute('style', 'overflow: scroll');
+			document.body.setAttribute('style', 'overflow: scroll');
+			ok(
+				document.scrollingElement === document.body ||
+				document.scrollingElement === document.documentElement,
+				'In standards mode, if the `BODY` is scrollable, the scrolling element is supposed to be `HTML`, but we’ll accept `BODY` too because that’s what WebKit/Blink use. Actual result: ' + document.scrollingElement.tagName
+			);
+		});
 		test('after switching to quirks mode in a non-frameset document, the scrolling element is `BODY`', function() {
 			documentWritePreserveQunit(false);
 			strictEqual(


### PR DESCRIPTION
Even when the body element has a scrolling box, do not return null when
the document is not in quirks mode.

I have left out the behavior I observed in Chrome of returning body when
in quirks mode even if the body element has a scrolling box, as I am not
completely certain how to interpret the spec and what this polyfill ought
to do in that case.

Closes #22 